### PR TITLE
Fix TTFT reporting for speculative prefill and support prompt files

### DIFF
--- a/speculative_prefill/hf_speculative_prefill.py
+++ b/speculative_prefill/hf_speculative_prefill.py
@@ -1,73 +1,341 @@
+import math
 import torch
-from torch import nn
-from typing import List
+from torch.nn import functional as F
+import time
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
 from transformers import AutoModelForCausalLM, AutoTokenizer
-from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
+from transformers.utils import WEIGHTS_NAME
+from transformers.models.llama.modeling_llama import (
+    apply_rotary_pos_emb,
+    eager_attention_forward,
+    ALL_ATTENTION_FUNCTIONS,
+)
+
+torch.backends.cuda.enable_flash_sdp(True)  # use Flash-Attention-2 kernels
+dtype = torch.float16  # keep AWQ de-quant in fp16
 
 
 class HFFSpeculativePrefill:
     """Standalone speculative prefill implementation using HuggingFace models."""
 
-    def __init__(self, base_model: str, spec_model: str, look_ahead: int = 4, keep_percentage: float = 0.5, device: str = "cuda"):
-        self.base_model = AutoModelForCausalLM.from_pretrained(base_model).to(device)
-        self.spec_model = AutoModelForCausalLM.from_pretrained(spec_model).to(device)
-        self.tokenizer = AutoTokenizer.from_pretrained(base_model)
-        self.spec_tokenizer = AutoTokenizer.from_pretrained(spec_model)
+    def __init__(
+        self,
+        base_model: str,
+        spec_model: str,
+        look_ahead: int = 4,
+        keep_percentage: float = 0.5,
+        *,
+        pool_kernel_size: Optional[int] = None,
+        chunk_size: Optional[int] = None,
+        tensor_parallel: Optional[bool] = None,
+        device: str = "cuda",
+        speculative: bool = True,
+    ) -> None:
         self.look_ahead = look_ahead
         self.keep_percentage = keep_percentage
-        self.device = device
+        self.pool_kernel_size = pool_kernel_size
+        self.chunk_size = chunk_size
+        self.tensor_parallel = tensor_parallel
+        self.speculative = speculative
+
+        if device.startswith("cuda"):
+            try:
+                from autoawq import AutoAWQForCausalLM
+            except Exception as exc:  # pragma: no cover - optional dependency
+                raise ImportError(
+                    "autoawq is required to load AWQ models"
+                ) from exc
+
+            base = AutoAWQForCausalLM.from_quantized(
+                base_model,
+                device_map="auto",
+                max_memory={0: "72GiB", 1: "72GiB", "cpu": "4GiB"},
+                fuse_layers=True,
+                use_flash_attention_2=True,
+            )
+            tokenizer = AutoTokenizer.from_pretrained(base_model)
+            self.base_model = base
+            self.tokenizer = tokenizer
+            self.device = "cuda:0"  # prompt accumulators stay on GPU-0
+        else:
+            self.base_model = AutoModelForCausalLM.from_pretrained(base_model).to(device)
+            self.tokenizer = AutoTokenizer.from_pretrained(base_model)
+            self.device = device
+
         self.base_model.eval()
-        self.spec_model.eval()
+
+        if self.speculative:
+            if device.startswith("cuda"):
+                spec = AutoModelForCausalLM.from_pretrained(
+                    spec_model,
+                    device_map={"": 1},
+                    torch_dtype=dtype,
+                    low_cpu_mem_usage=True,
+                )
+            else:
+                spec = AutoModelForCausalLM.from_pretrained(spec_model).to(device)
+            self.spec_model = spec
+            self.spec_tokenizer = AutoTokenizer.from_pretrained(spec_model)
+            self.spec_device = next(self.spec_model.parameters()).device
+            self.spec_model.eval()
+            self._patch_speculator_attn()
+        else:
+            self.spec_model = None
+            self.spec_tokenizer = None
+            self.spec_device = device
+
+    def _load_prompt(self, prompt: Union[str, Path]) -> str:
+        """Return prompt text, reading from file if ``prompt`` is a path."""
+        p = Path(prompt)
+        if p.exists():
+            return p.read_text().strip()
+        return str(prompt)
 
     @torch.no_grad()
-    def __call__(self, prompt: str) -> torch.Tensor:
-        base_ids = self.tokenizer(prompt, return_tensors="pt").input_ids.to(self.device)
-        spec_ids = self.spec_tokenizer(prompt, return_tensors="pt").input_ids.to(self.device)
-
-        # 1. run base model to collect key cache from context
-        base_out = self.base_model(base_ids, use_cache=True, output_hidden_states=True, return_dict=True)
-        base_keys = [k.squeeze(0) for k, _ in base_out.past_key_values]
-        base_hidden = base_out.hidden_states
-
+    def __call__(self, prompt: Union[str, Path]) -> torch.Tensor:
+        text = self._load_prompt(prompt)
+        base_ids = self.tokenizer(text, return_tensors="pt").input_ids.to(
+            self.device
+        )
         seq_len = base_ids.size(1)
+        steps = self.look_ahead
 
-        # 2. look-ahead speculation using speculator model
-        spec_cache = None
-        queries_per_step: List[torch.Tensor] = []
+        if not self.speculative:
+            pos_ids = torch.arange(seq_len, device=self.device).unsqueeze(0)
+            self.last_final_ids = base_ids
+            self.last_position_ids = pos_ids
+            return self.base_model(base_ids, position_ids=pos_ids).logits
+
+        spec_ids = self.spec_tokenizer(text, return_tensors="pt").input_ids.to(
+            self.spec_device
+        )
+
+        # 1. run speculator on context to build key cache
+        spec_out = self.spec_model(spec_ids, use_cache=True, return_dict=True)
+        spec_cache = spec_out.past_key_values
+        spec_keys = [k.squeeze(0) for k, _ in spec_cache]
+        layer_queries = [qbuf[-1] for qbuf in self.query_buffer]
+        queries_per_step: List[torch.Tensor] = [
+            torch.stack(layer_queries, dim=0)
+        ]
+        self._clear_query_buffer()
+
+        if steps == 0:
+            pos_ids = torch.arange(seq_len, device=self.device).unsqueeze(0)
+            self.last_final_ids = base_ids
+            self.last_position_ids = pos_ids
+            return self.base_model(base_ids, position_ids=pos_ids).logits
+
+        outputs = spec_out
         new_tokens: List[torch.Tensor] = []
-        for step in range(self.look_ahead):
-            outputs = self.spec_model(spec_ids if spec_cache is None else spec_ids[:, -1:],
-                                       use_cache=True, past_key_values=spec_cache,
-                                       output_hidden_states=True, return_dict=True)
-            spec_cache = outputs.past_key_values
-            last_h = [h[:, -1:, :] for h in outputs.hidden_states[1:]]
-            layer_queries = []
-            for layer_idx, h in enumerate(last_h):
-                attn = self.spec_model.model.layers[layer_idx].self_attn
-                pos = torch.tensor([[seq_len + step]], device=self.device)
-                cos, sin = self.spec_model.model.rotary_emb(h, pos)
-                q = attn.q_proj(h)
-                k = attn.k_proj(h)
-                q = q.view(1, 1, attn.num_attention_heads, attn.head_dim).transpose(1, 2)
-                k = k.view(1, 1, attn.num_key_value_heads, attn.head_dim).transpose(1, 2)
-                q, _ = apply_rotary_pos_emb(q, k, cos, sin)
-                layer_queries.append(q.squeeze(1))
-            queries_per_step.append(torch.stack(layer_queries))
+        for _ in range(steps):
             next_token = outputs.logits[:, -1].argmax(dim=-1, keepdim=True)
-            new_tokens.append(next_token)
+            outputs = self.spec_model(
+                next_token,
+                use_cache=True,
+                past_key_values=spec_cache,
+                return_dict=True,
+            )
+            spec_cache = outputs.past_key_values
+            layer_queries = [qbuf[-1] for qbuf in self.query_buffer]
+            queries_per_step.append(torch.stack(layer_queries, dim=0))
+            self._clear_query_buffer()
             spec_ids = torch.cat([spec_ids, next_token], dim=1)
-            if next_token.item() == self.tokenizer.eos_token_id:
+            token_id = next_token.item()
+            text = self.spec_tokenizer.decode([token_id], skip_special_tokens=True)
+            mapped = (
+                self.tokenizer(
+                    text, add_special_tokens=False, return_tensors="pt"
+                )
+                .input_ids.to(self.device)
+            ).long()
+            new_tokens.append(mapped)
+            if token_id == self.spec_tokenizer.eos_token_id:
                 break
 
-        queries = torch.stack(queries_per_step, dim=2)  # [layer, head, step, dim]
-        keys = torch.stack(base_keys)  # [layer, head, seq, dim]
-        attn = torch.einsum("lhsd, lhnd -> lhsn", queries, keys) / (queries.shape[-1] ** 0.5)
-        attn = attn.mean(2).max(1)[0]
-        token_importance = attn.mean(0)
+        # 2. compute attention scores between speculator queries and keys
+        queries = torch.stack(queries_per_step, dim=0).permute(1, 2, 0, 3)
+        is_tp = self._is_tensor_parallel()
+        if is_tp:
+            queries = self._gather_head_dim(queries)
+        keys = torch.stack(spec_keys, dim=0)
+        repeat_factor = (
+            self.spec_model.config.num_attention_heads
+            // self.spec_model.config.num_key_value_heads
+        )
+        keys = keys.repeat_interleave(repeat_factor, dim=1)
+        if is_tp:
+            keys = self._gather_head_dim(keys)
 
-        topk = max(1, int(seq_len * self.keep_percentage))
-        keep_idx = torch.topk(token_importance, k=topk).indices.sort().values
+        attn = torch.einsum("lhsd, lhnd -> lhsn", queries, keys) / math.sqrt(
+            queries.shape[-1]
+        )
+        attn = F.softmax(attn, dim=-1, dtype=torch.float32).to(queries.dtype)
+        attn = attn.flatten(0, 1)  # [layer*head, step, seq]
+
+        if self.pool_kernel_size and self.pool_kernel_size > 1:
+            attn = F.avg_pool1d(
+                attn,
+                kernel_size=self.pool_kernel_size,
+                padding=self.pool_kernel_size // 2,
+                stride=1,
+            )
+
+        attn = attn.max(dim=0)[0]  # [step, seq]
+        token_importance = attn.mean(dim=0)  # [seq]
+        token_importance = token_importance.to(self.device)
+
+        # 4. select important tokens optionally using chunking
+        if self.chunk_size and self.chunk_size > 0:
+            chunks = token_importance.split(self.chunk_size, dim=-1)
+            chunk_scores = torch.stack([c.mean() for c in chunks])
+            keep_chunks = max(1, math.ceil(len(chunks) * self.keep_percentage))
+            _, chunk_idx = torch.topk(chunk_scores, k=keep_chunks)
+            indices = torch.cat(
+                [
+                    torch.arange(
+                        i * self.chunk_size,
+                        min((i + 1) * self.chunk_size, seq_len),
+                        device=self.device,
+                    )
+                    for i in chunk_idx.tolist()
+                ]
+            )
+        else:
+            k = max(1, math.ceil(seq_len * self.keep_percentage))
+            _, indices = torch.topk(token_importance, k=k)
+
+        keep_idx = indices.sort().values
+        keep_idx = torch.unique(
+            torch.cat(
+                [keep_idx, torch.tensor([seq_len - 1], device=self.device)]
+            )
+        ).sort().values
         kept_ids = base_ids[:, keep_idx]
 
+        # kept context tokens must precede newly generated tokens
         final_ids = torch.cat([kept_ids] + new_tokens, dim=1)
-        return self.base_model(final_ids).logits
+        new_len = sum(t.size(1) for t in new_tokens)
+        pos_ids = torch.cat(
+            [
+                keep_idx.unsqueeze(0),
+                torch.arange(
+                    seq_len,
+                    seq_len + new_len,
+                    device=self.device,
+                ).unsqueeze(0),
+            ],
+            dim=1,
+        )
+        self.last_final_ids = final_ids
+        self.last_position_ids = pos_ids
+        pruned_text = self.tokenizer.decode(final_ids[0], skip_special_tokens=True)
+        print(f"Speculative prefill output: {pruned_text}")
+        return self.base_model(final_ids, position_ids=pos_ids).logits
+
+    def _is_tensor_parallel(self) -> bool:
+        if self.tensor_parallel is not None:
+            return self.tensor_parallel
+        return (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+            and torch.distributed.get_world_size() > 1
+        )
+
+    def _gather_head_dim(self, tensor: torch.Tensor) -> torch.Tensor:
+        if not self._is_tensor_parallel():
+            return tensor
+        world_size = torch.distributed.get_world_size()
+        parts = [torch.zeros_like(tensor) for _ in range(world_size)]
+        torch.distributed.all_gather(parts, tensor)
+        return torch.cat(parts, dim=1)
+
+    def _patch_speculator_attn(self) -> None:
+        self.query_buffer: List[List[torch.Tensor]] = [
+            [] for _ in range(self.spec_model.config.num_hidden_layers)
+        ]
+        for layer_idx, layer in enumerate(self.spec_model.model.layers):
+            attn = layer.self_attn
+
+            def forward(
+                self_attn,
+                hidden_states: torch.Tensor,
+                position_embeddings: tuple,
+                attention_mask: Optional[torch.Tensor],
+                past_key_value: Optional[tuple] = None,
+                cache_position: Optional[torch.LongTensor] = None,
+                _layer_idx: int = layer_idx,
+                **kwargs,
+            ):
+                input_shape = hidden_states.shape[:-1]
+                hidden_shape = (*input_shape, -1, self_attn.head_dim)
+
+                q = self_attn.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+                k = self_attn.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+                v = self_attn.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+                cos, sin = position_embeddings
+                q, k = apply_rotary_pos_emb(q, k, cos, sin)
+
+                if past_key_value is not None:
+                    cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+                    k, v = past_key_value.update(k, v, self_attn.layer_idx, cache_kwargs)
+
+                self.query_buffer[_layer_idx].append(q[0, :, -1, :])
+
+                attention_interface = eager_attention_forward
+                if self_attn.config._attn_implementation != "eager":
+                    attention_interface = ALL_ATTENTION_FUNCTIONS[
+                        self_attn.config._attn_implementation
+                    ]
+
+                attn_output, attn_weights = attention_interface(
+                    self_attn,
+                    q,
+                    k,
+                    v,
+                    attention_mask,
+                    dropout=0.0 if not self_attn.training else self_attn.attention_dropout,
+                    scaling=self_attn.scaling,
+                    **kwargs,
+                )
+
+                attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+                attn_output = self_attn.o_proj(attn_output)
+                return attn_output, attn_weights
+
+            attn.forward = forward.__get__(attn, type(attn))
+
+    def _clear_query_buffer(self) -> None:
+        for buf in self.query_buffer:
+            buf.clear()
+
+    def measure_ttft(
+        self, prompt: Union[str, Path], *, max_new_tokens: int = 16
+    ) -> float:
+        """Measure and print TTFT along with the model's full output.
+
+        The timing covers the entire speculative or non-speculative prefill up to
+        the base model's first token. Afterward, the base model continues to
+        generate ``max_new_tokens`` more tokens starting from the prompt used for
+        the prefill stage.
+        """
+        text = self._load_prompt(prompt)
+        start = time.perf_counter()
+        _ = self(text)
+        if self.device.startswith("cuda"):
+            torch.cuda.synchronize()
+        ttft = time.perf_counter() - start
+        label = "spec" if self.speculative else "no spec"
+        print(f"TTFT ({label}): {ttft:.4f}s")
+
+        gen_ids = self.base_model.generate(
+            self.last_final_ids,
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+        )
+        new_ids = gen_ids[0, self.last_final_ids.size(1) :]
+        out_text = self.tokenizer.decode(new_ids, skip_special_tokens=True)
+        print(out_text)
+        return ttft

--- a/tests/test_hf_speculative_prefill.py
+++ b/tests/test_hf_speculative_prefill.py
@@ -1,0 +1,212 @@
+import torch
+import sentencepiece as spm
+from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from speculative_prefill.hf_speculative_prefill import HFFSpeculativePrefill
+from unittest.mock import patch
+
+
+def build_tiny_llama(save_dir):
+    text_path = save_dir / "train.txt"
+    text_path.write_text("a b c d e f g h i j")
+    spm.SentencePieceTrainer.train(
+        input=str(text_path),
+        model_prefix=str(save_dir / "sp"),
+        vocab_size=24,
+        model_type="bpe",
+        bos_id=1,
+        eos_id=2,
+        unk_id=0,
+        pad_id=-1,
+    )
+    tokenizer = LlamaTokenizer(str(save_dir / "sp.model"))
+    tokenizer.save_pretrained(save_dir)
+    config = LlamaConfig(
+        vocab_size=tokenizer.vocab_size,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=4,
+        max_position_embeddings=64,
+    )
+    model = LlamaForCausalLM(config)
+    model.save_pretrained(save_dir)
+    return save_dir
+
+
+def test_speculative_prefill_matches_base(tmp_path):
+    model_dir = build_tiny_llama(tmp_path)
+    prefill = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=1,
+        keep_percentage=1.0,
+        tensor_parallel=False,
+        device="cpu",
+    )
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("a b")
+    logits_spec = prefill(prompt_path)
+    logits_base = prefill.base_model(
+        prefill.last_final_ids, position_ids=prefill.last_position_ids
+    ).logits
+    assert torch.allclose(logits_spec, logits_base)
+
+
+def test_disable_speculation(tmp_path):
+    model_dir = build_tiny_llama(tmp_path)
+    prefill = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=1,
+        keep_percentage=1.0,
+        tensor_parallel=False,
+        device="cpu",
+        speculative=False,
+    )
+    assert prefill.spec_model is None
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("a b")
+    prompt_text = prompt_path.read_text()
+    logits = prefill(prompt_path)
+    base_ids = prefill.tokenizer(prompt_text, return_tensors="pt").input_ids
+    pos_ids = torch.arange(0, base_ids.size(1)).unsqueeze(0)
+    logits_base = prefill.base_model(base_ids, position_ids=pos_ids).logits
+    assert torch.allclose(logits, logits_base)
+
+
+def test_measure_ttft(tmp_path, capsys):
+    model_dir = build_tiny_llama(tmp_path)
+    prefill_spec = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=1,
+        keep_percentage=1.0,
+        tensor_parallel=False,
+        device="cpu",
+    )
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("a b")
+    spec_time = prefill_spec.measure_ttft(prompt_path)
+    captured_spec = capsys.readouterr().out
+    spec_lines = captured_spec.strip().splitlines()
+    assert any(line.startswith("TTFT (spec):") for line in spec_lines)
+    gen_spec = prefill_spec.base_model.generate(
+        prefill_spec.last_final_ids, max_new_tokens=16, do_sample=False
+    )[0]
+    expected_spec = prefill_spec.tokenizer.decode(
+        gen_spec[prefill_spec.last_final_ids.size(1) :],
+        skip_special_tokens=True,
+    )
+    assert spec_lines[-1] == expected_spec
+    assert isinstance(spec_time, float)
+
+    prefill_base = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=1,
+        keep_percentage=1.0,
+        tensor_parallel=False,
+        device="cpu",
+        speculative=False,
+    )
+    base_time = prefill_base.measure_ttft(prompt_path)
+    captured_base = capsys.readouterr().out
+    base_lines = captured_base.strip().splitlines()
+    assert any(line.startswith("TTFT (no spec):") for line in base_lines)
+    gen_base = prefill_base.base_model.generate(
+        prefill_base.last_final_ids, max_new_tokens=16, do_sample=False
+    )[0]
+    expected_base = prefill_base.tokenizer.decode(
+        gen_base[prefill_base.last_final_ids.size(1) :],
+        skip_special_tokens=True,
+    )
+    assert base_lines[-1] == expected_base
+    assert isinstance(base_time, float)
+
+
+def test_speculator_runs_once_when_zero_steps(tmp_path):
+    model_dir = build_tiny_llama(tmp_path)
+    prefill = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=0,
+        keep_percentage=1.0,
+        tensor_parallel=False,
+        device="cpu",
+    )
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("a b")
+    with patch.object(prefill.spec_model, "forward", wraps=prefill.spec_model.forward) as fwd:
+        prefill(prompt_path)
+        assert fwd.call_count == 1
+
+
+def test_measure_ttft_zero_lookahead(tmp_path, capsys):
+    model_dir = build_tiny_llama(tmp_path)
+    prefill = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=0,
+        keep_percentage=1.0,
+        tensor_parallel=False,
+        device="cpu",
+    )
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("a b")
+    ttft = prefill.measure_ttft(prompt_path)
+    output = capsys.readouterr().out
+    lines = output.strip().splitlines()
+    assert any(line.startswith("TTFT (spec):") for line in lines)
+    gen = prefill.base_model.generate(
+        prefill.last_final_ids, max_new_tokens=16, do_sample=False
+    )[0]
+    expected = prefill.tokenizer.decode(
+        gen[prefill.last_final_ids.size(1) :], skip_special_tokens=True
+    )
+    assert lines[-1] == expected
+    assert isinstance(ttft, float)
+
+
+def test_prefill_prints_pruned_tokens(tmp_path, capsys):
+    model_dir = build_tiny_llama(tmp_path)
+    prefill = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=1,
+        keep_percentage=0.5,
+        tensor_parallel=False,
+        device="cpu",
+    )
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("a b c d")
+    prefill(prompt_path)
+    out = capsys.readouterr().out
+    assert "Speculative prefill output:" in out
+
+
+def test_last_prompt_token_preserved(tmp_path):
+    model_dir = build_tiny_llama(tmp_path)
+    prefill = HFFSpeculativePrefill(
+        str(model_dir),
+        str(model_dir),
+        look_ahead=1,
+        keep_percentage=0.25,
+        tensor_parallel=False,
+        device="cpu",
+    )
+    prompt_path = tmp_path / "prompt.txt"
+    prompt_path.write_text("a b c d e")
+    prefill(prompt_path)
+    prompt_text = prompt_path.read_text()
+    base_ids = prefill.tokenizer(prompt_text, return_tensors="pt").input_ids
+    seq_len = base_ids.size(1)
+    keep_mask = prefill.last_position_ids[0] < seq_len
+    kept_positions = prefill.last_position_ids[0][keep_mask]
+    assert (seq_len - 1) in kept_positions
+


### PR DESCRIPTION
## Summary
- ensure the speculator runs once even when look-ahead is zero so speculative TTFT is recorded
- measure TTFT based only on the `speculative` flag and update tests for zero look-ahead
- print the speculative prefill sequence before the base model forward to reveal pruned prompt tokens
- allow passing a text-file path so the prefill pipeline reads the prompt from disk
- capture the prompt's final-token query and always keep it so pruning never drops the last context token
- load the base and speculator models with Accelerate, distributing the base across two GPUs and pinning the speculator to GPU-1 to avoid CUDA memory spikes
- print decoded model output immediately after TTFT is reported in both speculative and baseline modes
- load AWQ base models with `AutoAWQForCausalLM.from_quantized` so quantized weights live on GPU
- print only tokens generated after the prefill stage when reporting model output

## Testing
- `python -m py_compile speculative_prefill/hf_speculative_prefill.py tests/test_hf_speculative_prefill.py`
- `pytest tests/test_hf_speculative_prefill.py -q`
- `pip install autoawq` *(fails: No matching distribution found for autoawq)*

------
https://chatgpt.com/codex/tasks/task_e_6890c5ad278883329acd703238c39d80